### PR TITLE
added base date setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ exports.parse = function (dateString, alternativeSettings) {
             day_before_month: settings.get('day_before_month'),
             strict: settings.get('strict'),
             gmt: settings.get('gmt'),
+            base_date: settings.get('base_date'),
         }
         currentSettings.set(getter);
 

--- a/model/compiler.js
+++ b/model/compiler.js
@@ -21,7 +21,7 @@ exports.calculateDate = function (dateString, matches, settings) {
     }
 
     // New state each time
-    var state = new State();
+    var state = new State(settings);
 
     for (var match of matches) {
 

--- a/model/language_manager.js
+++ b/model/language_manager.js
@@ -167,6 +167,7 @@ var russianTokens = [
     require('./tokens/russian/months.js').tokens,
     require('./tokens/russian/last&next.js').tokens,
     require('./tokens/russian/ago&since.js').tokens,
+    require('./tokens/russian/now.js').tokens,
     require('./tokens/russian/yesterday&tomorrow.js').tokens
 ];
 

--- a/model/settings.js
+++ b/model/settings.js
@@ -15,10 +15,15 @@ function Settings(alternativeSettings) {
             gmt: 'auto',
             desc: 'The GMT offset to add to the date in hours (e.g. -3)'
         },
+        base_date : {
+            base_date: new Date(),
+            desc: 'What is the date from which you wish to calculate a relative date? (yesterday for 2010/10/10 != yesterday for today)'
+        },
         restore: function() {
             that.set({'gmt':'auto',
                       'day_before_month':true,
-                      'strict':false});
+                      'strict':false,
+                      'base_date':new Date()});
         }
     }; 
     

--- a/model/state.js
+++ b/model/state.js
@@ -5,12 +5,10 @@ var moment = require('moment');
 const absolute = consts.reltivity.absolute;
 
 // ctor
-function State() {
+function State(settings) {
 
     // Init date as current
-    this.date = moment();
-    this.date.seconds(0);
-    this.date.milliseconds(0);
+    this.date = moment(settings.settings.base_date.base_date);    
 
     // Init the modification queue that logs the modification on each date part
     this.modificationQueues = [];

--- a/model/tokens/english/now.js
+++ b/model/tokens/english/now.js
@@ -4,35 +4,35 @@ exports.tokens = [
     {
         example: 'now',
         category: 'now',
-        regex: /(?:\b|^)now(?:\b|$)/,
-        affectsGenerator: function () {
-            var now = new Date();
+        regex: /(?:\b|^)now|today(?:\b|$)/,
+        affectsGenerator: function (match, settings) {
+            var currentDate = settings.settings.base_date.base_date;
 
             return [
                 {
                     timeType: consts.timeTypes.year,
                     affectType: consts.reltivity.absolute,
-                    value: now.getFullYear()
+                    value: currentDate.getFullYear()
                 },
                 {
                     timeType: consts.timeTypes.month,
                     affectType: consts.reltivity.absolute,
-                    value: now.getMonth() + 1 //  <-- stupidest thing in js :(
+                    value: currentDate.getMonth() + 1
                 },
                 {
                     timeType: consts.timeTypes.day,
                     affectType: consts.reltivity.absolute,
-                    value: now.getDate()
+                    value: currentDate.getDate()
                 },
                 {
                     timeType: consts.timeTypes.hour,
                     affectType: consts.reltivity.absolute,
-                    value: now.getHours()
+                    value: currentDate.getHours()
                 },
                 {
                     timeType: consts.timeTypes.minute,
                     affectType: consts.reltivity.absolute,
-                    value: now.getMinutes()
+                    value: currentDate.getMinutes()
                 }];
         }
     }

--- a/model/tokens/russian/now.js
+++ b/model/tokens/russian/now.js
@@ -5,34 +5,34 @@ exports.tokens = [
         example: 'только что',
         category: 'now',
         regex: /(?:\b|^)только что(?:\b|$)/,
-        affectsGenerator: function () {
-            var now = new Date();
+        affectsGenerator: function (match, settings) {
+            var currentDate = settings.settings.base_date.base_date;
 
             return [
                 {
                     timeType: consts.timeTypes.year,
                     affectType: consts.reltivity.absolute,
-                    value: now.getFullYear()
+                    value: currentDate.getFullYear()
                 },
                 {
                     timeType: consts.timeTypes.month,
                     affectType: consts.reltivity.absolute,
-                    value: now.getMonth() + 1 //  <-- stupidest thing in js :(
+                    value: currentDate.getMonth() + 1
                 },
                 {
                     timeType: consts.timeTypes.day,
                     affectType: consts.reltivity.absolute,
-                    value: now.getDate()
+                    value: currentDate.getDate()
                 },
                 {
                     timeType: consts.timeTypes.hour,
                     affectType: consts.reltivity.absolute,
-                    value: now.getHours()
+                    value: currentDate.getHours()
                 },
                 {
                     timeType: consts.timeTypes.minute,
                     affectType: consts.reltivity.absolute,
-                    value: now.getMinutes()
+                    value: currentDate.getMinutes()
                 }];
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "its-a-date",
   "description": "A Natural Language Date Description Processor",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "main": "index.js",
   "scripts": {
     "test": "tape test.js | tap-min"
@@ -50,8 +50,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "franc": "4.0.0",
-    "lodash": "4.17.11",
+    "franc": "^4.0.0",
+    "lodash": "^4.17.11",
     "moment": "2.14.1"
   },
   "keywords": [

--- a/playground.js
+++ b/playground.js
@@ -1,8 +1,33 @@
 var itsadate = require('./index.js');
 
 // Playground starts here --->
+var currentDate = new Date(2010, 10, 10)
+var settings = {
+    format_hints: {
+            day_before_month: true,
+            desc : 'When true then its-a-date expects dd/mm/yyyy, otherwise mm/dd/yyyy'
+    },
+    hint_strict: {
+        strict: false,
+        desc: 'when not strict, its-a-date will try different formats to prevent error'
+    },
+    timezone : {
+        gmt: 'auto',
+        desc: 'The GMT offset to add to the date in hours (e.g. -3)'
+    },
+    base_date : {
+        base_date: currentDate,
+        desc: 'What is the date from which you wish to calculate a relative date? (yesterday for 2010/10/10 != yesterday for today)'
+    },
+    restore: function() {
+        that.set({'gmt':'auto',
+                  'day_before_month':true,
+                  'strict':false,
+                  'base_date':new Date()});
+    }
+}; 
 
-var s = itsadate.parse('10/11/17');
+var s = itsadate.parse('Только что', settings);
 
 console.log(s);
 


### PR DESCRIPTION
Added a setting called base_date that enables choosing from when the date should be calculated.
For example, '3 days ago' with a base date of 10/10/2019 returns 07/10/2019.
Not specifying a base_date setting defaults to the current date and time.